### PR TITLE
Import error reporting when misusing db.CreateCollection()

### DIFF
--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -149,7 +149,9 @@ class Collection_metaclass(type) :
         try :
             return cls.collectionClasses[name]
         except KeyError :
-            raise KeyError("There's no child of Collection by the name of: %s" % name)
+            raise KeyError("There is no Collection Class of type: '%s';"+
+                           " currently supported values: [%s]"
+                           % (name, ', '.join(getCollectionClasses().keys())))
 
     @classmethod
     def isCollection(cls, name) :

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -69,6 +69,8 @@ class Connection(object) :
     def __init__(self, arangoURL = 'http://localhost:8529', username=None, password=None) :
         self.databases = {}
         if arangoURL[-1] == "/" :
+            if ('url' not in vars()):
+                raise Exception("you either need to define `url` or make arangoURL contain an HTTP-Host")
             self.arangoURL = url[:-1]
         else :
             self.arangoURL = arangoURL


### PR DESCRIPTION
When misusing db.createCollection() the error message is meaningless to a novice user. improve this.

Hopefully git works for me this time ;-)