### PR TITLE
Fix connection object

### DIFF
--- a/examples/debiangraph.py
+++ b/examples/debiangraph.py
@@ -1,10 +1,22 @@
-#!python3
-# # example to build a file with all packages known to your system for a debian jessie:
-# for i in `ls /var/lib/apt/lists/*debian_dists_jessie_* |grep -v i386 |grep -v Release`; do cat $i >> /tmp/allpackages; echo >> /tmp/allpackages; done 
-# # (all debian based distros have a set of files in /var/lib/apt/lists; in doubt create a filter for your distro)
+#/usr/bin/env python3
+"""
+example to build a file with all packages known to your system for a debian jessie:
 
-# pip3 install pyArango
-# pip3 install deb_pkg_tools
+for i in $(ls /var/lib/apt/lists/*debian_dists_jessie_* |\
+           grep -v i386 |grep -v Release); do
+    cat $i >> /tmp/allpackages;
+    echo >> /tmp/allpackages;
+done
+
+All debian based distros have a set of files in /var/lib/apt/lists.
+In doubt create a filter for your distro
+
+Install needed Python modules:
+
+pip3 install pyArango
+pip3 install deb_pkg_tools
+"""
+
 import deb_pkg_tools
 from deb_pkg_tools.control import deb822_from_string
 from deb_pkg_tools.control import parse_control_fields
@@ -16,30 +28,48 @@ from pyArango.query import *
 from pyArango.graph import *
 from pyArango.theExceptions import *
 
-# we expect the server to be available on localhost.
-conn = Connection(arangoURL = "http://localhost:8529", username="root", password="")
+# Configure your ArangoDB server connection here
+conn = Connection(arango_url="http://localhost:8529", username="USERNAME", password="SECRET")
+
+db = None
+edgeCols = {}
+packagesCol = {}
+
 # we create our own database so we don't interfere with userdata:
-db = {}
-if not conn.hasDatabase("testdb"): 
+
+if not conn.hasDatabase("testdb"):
     db = conn.createDatabase("testdb")
 else:
     db = conn["testdb"]
 
-packagesCol = {}
 if not db.hasCollection('packages'):
     packagesCol = db.createCollection('Collection', name='packages')
-else:    
+else:
     packagesCol = db.collections['packages']
 
-edgeCols = {}
+
 def getEdgeCol(name):
-    global edgeCols, db
     if not name in edgeCols:
         if not db.hasCollection(name):
-            edgeCols[name] = db.createCollection(name=name, className = 'Edges')
+            edgeCols[name] = db.createCollection(name=name, className='Edges')
         else:
-            edgeCols[name] = edgeCol = db.collections[name]
+            edgeCols[name] = db.collections[name]
     return edgeCols[name]
+
+
+def saveGraphDefinition():
+    graph_collection = db.collections["_graphs"]
+    graph_defintion = {
+        "_key": "debian_dependency_graph",
+        "edgeDefinitions": [],
+        "orphanCollections": [],
+    }
+    for collection in edgeCols.keys():
+        graph_defintion["edgeDefinitions"].append(
+            {"collection": collection,
+             "from": ["packages",],
+             "to": ["packages",]})
+    graph_collection.createDocument(graph_defintion).save()
 
 
 def VersionedDependencyToDict(oneDep, hasAlternatives):
@@ -50,11 +80,13 @@ def VersionedDependencyToDict(oneDep, hasAlternatives):
         'hasAlternatives': hasAlternatives
         }
 
+
 def DependencyToDict(oneDep, hasAlternatives):
-        return {
-            'name': oneDep.name,
-            'hasAlternatives': hasAlternatives
-            }
+    return {
+        'name': oneDep.name,
+        'hasAlternatives': hasAlternatives
+        }
+
 
 def DependencySetToDict(dep, hasAlternatives):
     depset = []
@@ -67,30 +99,32 @@ def DependencySetToDict(dep, hasAlternatives):
             depset.append(DependencyToDict(oneDep, hasAlternatives))
         else:
             print("Unknown relationshitp: " + repr(oneDep))
-            
     return depset
+
 
 def PackageToDict(pkg):
     # packages aren't serializable by default, translate it:
     ret = {}
-    for key in pkg.keys():
-        if isinstance(pkg[key], deb_pkg_tools.deps.RelationshipSet):
+    for attribute in pkg.keys():
+        if isinstance(pkg[attribute], deb_pkg_tools.deps.RelationshipSet):
             # relation ship field to become an array of relations:
-            ret[key] = DependencySetToDict(pkg[key], False)
+            ret[attribute] = DependencySetToDict(pkg[attribute], False)
         else:
             # regular string field:
-            ret[key] = pkg[key]
+            ret[attribute] = pkg[attribute]
+    ret["_key"] = ret["Package"]
     return ret
 
+
 def saveDependencyToEdgeCol(edgeCol, dep, pname, hasAlternatives):
-    for oneDep in dep.relationships: 
+    for oneDep in dep.relationships:
         if isinstance(oneDep, deb_pkg_tools.deps.VersionedRelationship):
             # version dependend relations:
             d = VersionedDependencyToDict(oneDep, hasAlternatives)
             d['_from'] = 'packages/' + pname
             d['_to'] = 'packages/' + oneDep.name
             relation = edgeCol.createDocument(d).save()
-        elif isinstance(oneDep, deb_pkg_tools.deps.AlternativeRelationship): 
+        elif isinstance(oneDep, deb_pkg_tools.deps.AlternativeRelationship):
             # A set of alternative relations; recurse:
             saveDependencyToEdgeCol(edgeCol, oneDep, pname, True)
         elif isinstance(oneDep, deb_pkg_tools.deps.Relationship):
@@ -102,6 +136,10 @@ def saveDependencyToEdgeCol(edgeCol, dep, pname, hasAlternatives):
         else:
             print("Unknown relationshitp: " + repr(oneDep))
 
+#
+# Main import routine
+#
+
 onePackage = ''
 for line in open('/tmp/allpackages', encoding='utf-8'):
     # Package blocks are separated by new lines.
@@ -110,13 +148,17 @@ for line in open('/tmp/allpackages', encoding='utf-8'):
         pname = pkg['Package']
         pkg1 = parse_control_fields(pkg)
         p = PackageToDict(pkg1)
-        packagesCol.createDocument(p).save()
-        
-        for key in pkg1.keys():
-            # filter for fields with relations:
-            if isinstance(pkg1[key], deb_pkg_tools.deps.RelationshipSet):
-                # save one relation set to field:
-                saveDependencyToEdgeCol(getEdgeCol(key), pkg1[key], pname, False) 
-        onePackage = ''
+        try:
+            packagesCol.createDocument(p).save()
+            for key in pkg1.keys():
+                # filter for fields with relations:
+                if isinstance(pkg1[key], deb_pkg_tools.deps.RelationshipSet):
+                    # save one relation set to field:
+                    saveDependencyToEdgeCol(getEdgeCol(key), pkg1[key], pname, False)
+            onePackage = ''
+        except CreationError:
+            pass
     else:
         onePackage += line
+
+saveGraphDefinition()

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -1,158 +1,104 @@
-import requests
+#!/usr/bin/env python
+"""main pyArongo connection class"""
+
 import json
+import requests
 
 from .database import Database, DBHandle
-from .theExceptions import SchemaViolation, CreationError, ConnectionError
+from .theExceptions import CreationError, ConnectionError
 from .users import Users
 
-class JsonHook(object) :
-    """This one replaces requests' original json() function. If a call to json() fails, it will print a message with the request content"""
-    def __init__(self, ret) :
-        self.ret = ret
-        self.ret.json_originalFct = self.ret.json
-    
-    def __call__(self, *args, **kwargs) :
-        try :
-            return self.ret.json_originalFct(*args, **kwargs)
-        except Exception as e :
-            print( "Unable to get json for request: %s. Content: %s" % (self.ret.url, self.ret.content) )
-            raise e 
 
-class AikidoSession(object) :
-    """Magical Aikido being that you probably do not need to access directly that deflects every http request to requests in the most graceful way.
-    It will also save basic stats on requests in it's attribute '.log'.
-    """
-
-    class Holder(object) :
-        def __init__(self, session, fct) :
-            self.session = session
-            self.fct = fct
-
-        def __call__(self, *args, **kwargs) :
-
-            if self.session.auth :
-                kwargs["auth"] = self.session.auth
-
-            try :
-                with self.session.session as s:
-                   ret = self.fct(*args, **kwargs)
-            except :
-                print ("===\nUnable to establish connection, perhaps arango is not running.\n===")
-                raise
-
-            if ret.status_code == 401 :
-                raise ConnectionError("Unauthorized access, you must supply a (username, password) with the correct credentials", ret.url, ret.status_code, ret.content)
-
-            ret.json = JsonHook(ret)
-            return ret
-
-    def __init__(self, username, password) :
-        if username :
-            self.auth = (username, password)
-        else :
-            self.auth = None
-
-        self.session = requests.Session()
-        self.log = {}
-        self.log["nb_request"] = 0
-        self.log["requests"] = {}
-
-    def __getattr__(self, k) :
-        try :
-            reqFct = getattr(object.__getattribute__(self, "session"), k)
-        except :
-            raise AttributeError("Attribute '%s' not found (no Aikido move available)" % k)
-
-        holdClass = object.__getattribute__(self, "Holder")
-        log = object.__getattribute__(self, "log")
-        log["nb_request"] += 1
-        try :
-            log["requests"][reqFct.__name__] += 1
-        except :
-            log["requests"][reqFct.__name__] = 1
-
-        return holdClass(self, reqFct)
-
-    def disconnect(self) :
-        try:
-            self.session.connection.close()
-        except Exception :
-            pass
-
-class Connection(object) :
+class Connection(object):
     """This is the entry point in pyArango and directly handles databases."""
-    def __init__(self, arangoURL = 'http://127.0.0.1:8529', username=None, password=None) :
-        self.databases = {}
-        if arangoURL[-1] == "/" :
-            if ('url' not in vars()):
-                raise Exception("you either need to define `url` or make arangoURL contain an HTTP-Host")
-            self.arangoURL = url[:-1]
-        else :
+    def __init__(self, arango_url='http://127.0.0.1:8529', username="", password="",
+                 arangoURL=""):
+        self.arango_url = arango_url
+        if arangoURL:
+            # TODO deprecation warning
+            self.arango_url = arangoURL
             self.arangoURL = arangoURL
+        self.base_url = arango_url.rstrip("/")  # shouldn't have trailing slashes
+        self.api_url = self.base_url + "/_api"
+        self.db_url = self.api_url + "/database/user"
+        self.username = username
+        self.password = password
+        self.databases = {}
+        self.session = requests.Session()
 
-        self.session = None
-        self.resetSession(username, password)
-
-        self.URL = '%s/_api' % self.arangoURL
-        if not self.session.auth :
-            self.databasesURL = '%s/database/user' % self.URL
-        else :
-            self.databasesURL = '%s/user/%s/database' % (self.URL, username)
+        if self.username:
+            self.session.auth = (self.username, self.password)
+            self.db_url = self.api_url + "/user/" + self.username + "/database"
 
         self.users = Users(self)
         self.reload()
 
-    def disconnectSession(self) :
-        if self.session != None: 
-            self.session.disconnect()
+    def disconnectSession(self):
+        if self.session:
+            self.session.close()
 
-    def resetSession(self, username=None, password=None) :
+    def resetSession(self, username="", password=""):
         """resets the session"""
         self.disconnectSession()
-        self.session = AikidoSession(username, password)
+        self.username = username or self.username
+        self.password = password or self.password
+        self.session = requests.Session()
 
-    def reload(self) :
-        """Reloads the database list.
-        Because loading a database triggers the loading of all collections and graphs within,
-        only handles are loaded when this function is called. The full databases are loaded on demand when accessed
+        if self.username:
+            self.session.auth = (self.username, self.password)
+            self.db_url = self.api_url + "/user/" + self.username + "/database"
+
+    def reload(self):
         """
+        Reloads the database list.  Because loading a database triggers the
+        loading of all collections and graphs within, only handles are loaded
+        when this function is called. The full databases are loaded on demand
+        when accessed """
 
-        r = self.session.get(self.databasesURL)
+        result = self.session.get(self.db_url)
 
-        data = r.json()
-        if r.status_code == 200 and not data["error"] :
+        data = result.json()
+        if result.status_code == 200 and not data["error"]:
             self.databases = {}
-            for dbName in data["result"] :
-                if dbName not in self.databases :
-                    self.databases[dbName] = DBHandle(self, dbName)
-        else :
-            raise ConnectionError(data["errorMessage"], self.databasesURL, r.status_code, r.content)
+            for db_name in data["result"]:
+                if db_name not in self.databases:
+                    self.databases[db_name] = DBHandle(self, db_name)
+        else:
+            raise ConnectionError(data["errorMessage"], self.db_url,
+                                  result.status_code, result.content)
 
-    def createDatabase(self, name, **dbArgs) :
-        "use dbArgs for arguments other than name. for a full list of arguments please have a look at arangoDB's doc"
+    def createDatabase(self, name, **dbArgs):
+        """
+        use dbArgs for arguments other than name. for a full list of arguments
+        please have a look at arangoDB's doc
+        """
         dbArgs['name'] = name
         payload = json.dumps(dbArgs)
-        url = self.URL + "/database"
-        r = self.session.post(url, data = payload)
-        data = r.json()
-        if r.status_code == 201 and not data["error"] :
-            db = Database(self, name)
-            self.databases[name] = db
+        url = self.api_url + "/database"
+        result = self.session.post(url, data=payload)
+        data = result.json()
+        if result.status_code == 201 and not data["error"]:
+            self.databases[name] = Database(self, name)
             return self.databases[name]
-        else :
-            raise CreationError(data["errorMessage"], r.content)
+        else:
+            raise CreationError(data["errorMessage"], result.content)
 
-    def hasDatabase(self, name) :
-        """returns true/false wether the connection has a database by the name of 'name'"""
+    def hasDatabase(self, name):
+        """
+        returns true/false wether the connection has a database by the name of 'name'
+        """
         return name in self.databases
 
-    def __getitem__(self, dbName) :
-        """Collection[dbName] returns a database by the name of 'dbName', raises a KeyError if not found"""
-        try :
-            return self.databases[dbName]
-        except KeyError :
+    def __getitem__(self, db_name):
+        """
+        Collection[db_name] returns a database by the name of 'dbName',
+        raises a KeyError if not found
+        """
+        try:
+            return self.databases[db_name]
+        except KeyError:
             self.reload()
-            try :
-                return self.databases[dbName]
-            except KeyError :
-                raise KeyError("Can't find any database named : %s" % dbName)
+            try:
+                return self.databases[db_name]
+            except KeyError:
+                raise KeyError("Can't find any database named: %s" % db_name)

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -56,7 +56,7 @@ class Connection(object):
         when accessed """
 
         result = self.session.get(self.db_url)
-
+        result.raise_for_status()
         data = result.json()
         if result.status_code == 200 and not data["error"]:
             self.databases = {}

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -21,7 +21,7 @@ class Database(object) :
         self.connection = connection
         self.collections = {}
 
-        self.URL = '%s/_db/%s/_api' % (self.connection.arangoURL, self.name)
+        self.URL = '%s/_db/%s/_api' % (self.connection.arango_url, self.name)
         self.collectionsURL = '%s/collection' % (self.URL)
         self.cursorsURL = '%s/cursor' % (self.URL)
         self.explainURL = '%s/explain' % (self.URL)

--- a/pyArango/graph.py
+++ b/pyArango/graph.py
@@ -91,11 +91,11 @@ class Graph(with_metaclass(Graph_metaclass, object)) :
                 raise KeyError("'%s' is not a valid edge collection" % de.name)
             self.definitions[de.name] = de
 
-        self.URL = "%s/%s" % (self.database.graphsURL, self._key)
+        self.api_url = "%s/%s" % (self.database.graphsURL, self._key)
 
     def createVertex(self, collectionName, docAttributes, waitForSync = False) :
         """adds a vertex to the graph and returns it"""
-        url = "%s/vertex/%s" % (self.URL, collectionName)
+        url = "%s/vertex/%s" % (self.api_url, collectionName)
         self.database[collectionName].validateDct(docAttributes)
 
         r = self.connection.session.post(url, data = json.dumps(docAttributes), params = {'waitForSync' : waitForSync})
@@ -108,7 +108,7 @@ class Graph(with_metaclass(Graph_metaclass, object)) :
 
     def deleteVertex(self, document, waitForSync = False) :
         """deletes a vertex from the graph as well as al linked edges"""
-        url = "%s/vertex/%s" % (self.URL, document._id)
+        url = "%s/vertex/%s" % (self.api_url, document._id)
 
         r = self.connection.session.delete(url, params = {'waitForSync' : waitForSync})
         data = r.json()
@@ -123,7 +123,7 @@ class Graph(with_metaclass(Graph_metaclass, object)) :
         if collectionName not in self.definitions :
             raise KeyError("'%s' is not among the edge definitions" % collectionName)
 
-        url = "%s/edge/%s" % (self.URL, collectionName)
+        url = "%s/edge/%s" % (self.api_url, collectionName)
         self.database[collectionName].validateDct(edgeAttributes)
         payload = edgeAttributes
         payload.update({'_from' : _fromId, '_to' : _toId})
@@ -146,7 +146,7 @@ class Graph(with_metaclass(Graph_metaclass, object)) :
 
     def deleteEdge(self, edge, waitForSync = False) :
         """removes an edge from the graph"""
-        url = "%s/edge/%s" % (self.URL, edge._id)
+        url = "%s/edge/%s" % (self.api_url, edge._id)
         r = self.connection.session.delete(url, params = {'waitForSync' : waitForSync})
         if r.status_code == 200 or r.status_code == 202 :
             return True
@@ -154,7 +154,7 @@ class Graph(with_metaclass(Graph_metaclass, object)) :
 
     def delete(self) :
         """deletes the graph"""
-        r = self.connection.session.delete(self.URL)
+        r = self.connection.session.delete(self.api_url)
         data = r.json()
         if r.status_code < 200 or r.status_code > 202 or data["error"] :
             raise DeletionError(data["errorMessage"], data)

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -731,6 +731,6 @@ if __name__ == "__main__" :
             inpFct = input
 
         ARANGODB_ROOT_USERNAME = inpFct("Please enter root username: ")
-        ARANGODB_ROOT_PASSWORD = inpFct("Please entre root password: ")
+        ARANGODB_ROOT_PASSWORD = inpFct("Please enter root password: ")
 
     unittest.main()

--- a/pyArango/users.py
+++ b/pyArango/users.py
@@ -30,7 +30,7 @@ class User(object) :
         except KeyError :
             self["password"] = ""
 
-        self.URL = "%s/user/%s" % (self.connection.URL, self["username"])
+        self.URL = self.connection.api_url +"/user/" + self["username"]
 
     def save(self):
         """Save/updates the user"""
@@ -110,7 +110,7 @@ class Users(object) :
     """This one manages users."""
     def __init__(self, connection) :
         self.connection = connection
-        self.URL = "%s/user" % (self.connection.URL)
+        self.URL = self.connection.api_url + "/user"
 
     def createUser(self, username, password) :
         u = User(self)


### PR DESCRIPTION
I was asked by @dothebart  to find the cause why each
request creates a new connection to the db api.

So I identified AikidoSession as the culprit as this
class loose the scope to the requests session object
which leads to a connection close.

Furthermore I've cleaned up the connection.py 
code a little bit. But as the current API method naming
doesn't fit pyhon pep specs, it's still not very clean
an pythonic.

If functionality of Aikido or the former JSONHook
is still needed or wanted:
I thinks this should be better implemented by using requests
hook method,  subclassing requests session and return objects
or decorators.