### PR TITLE
Adding possibilty to inject custom JSONEncoder into AQLQuery.

### DIFF
--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -170,10 +170,12 @@ class Database(object) :
         """returns true if the databse has a graph by the name of 'name'"""
         return name in self.graphs
 
-    def AQLQuery(self, query, batchSize = 100, rawResults = False, bindVars = {}, options = {}, count = False, fullCount = False, **moreArgs) :
+    def AQLQuery(self, query, batchSize = 100, rawResults = False, bindVars = {}, options = {}, count = False, fullCount = False,
+                 json_encoder = None, **moreArgs) :
         """Set rawResults = True if you want the query to return dictionnaries instead of Document objects.
         You can use **moreArgs to pass more arguments supported by the api, such as ttl=60 (time to live)"""
-        return AQLQuery(self, query, rawResults = rawResults, batchSize = batchSize, bindVars  = bindVars, options = options, count = count, fullCount = fullCount, **moreArgs)
+        return AQLQuery(self, query, rawResults = rawResults, batchSize = batchSize, bindVars  = bindVars, options = options, count = count, fullCount = fullCount,
+                        json_encoder = json_encoder, **moreArgs)
 
     def explainAQLQuery(self, query, allPlans = False) :
         """Returns an explanation of the query. Setting allPlans to True will result in ArangoDB returning all possible plans. False returns only the optimal plan"""

--- a/pyArango/query.py
+++ b/pyArango/query.py
@@ -131,14 +131,15 @@ class Query(object) :
 
 class AQLQuery(Query) :
     "AQL queries are attached to and instanciated by a database"
-    def __init__(self, database, query, batchSize, bindVars, options, count, fullCount, rawResults = True, **moreArgs) :
+    def __init__(self, database, query, batchSize, bindVars, options, count, fullCount, rawResults = True,
+                 json_encoder = None, **moreArgs) :
         payload = {'query' : query, 'batchSize' : batchSize, 'bindVars' : bindVars, 'options' : options, 'count' : count, 'fullCount' : fullCount}
         payload.update(moreArgs)
 
         self.query = query
         self.database = database
         self.connection = self.database.connection
-        request = self.connection.session.post(database.cursorsURL, data = json.dumps(payload))
+        request = self.connection.session.post(database.cursorsURL, data = json.dumps(payload, cls=json_encoder))
         Query.__init__(self, request, database, rawResults)
 
     def explain(self, allPlans = False) :
@@ -165,14 +166,15 @@ class Cursor(Query) :
 
 class SimpleQuery(Query) :
     "Simple queries are attached to and instanciated by a collection"
-    def __init__(self, collection, queryType, rawResults, **queryArgs) :
+    def __init__(self, collection, queryType, rawResults, json_encoder = None,
+                 **queryArgs) :
 
         self.collection = collection
         self.connection = self.collection.database.connection
 
         payload = {'collection' : collection.name}
         payload.update(queryArgs)
-        payload = json.dumps(payload)
+        payload = json.dumps(payload, cls=json_encoder)
         URL = "%s/simple/%s" % (collection.database.URL, queryType)
         request = self.connection.session.put(URL, data = payload)
 


### PR DESCRIPTION
Proposing to add functionality similar to the one in this PR. We need to be able to serialize slightly more complex objects than the ones the standard JSONEncoder can handle (such as datetime etc). Our solution was to pull out a json_encoder parameter to allow us to inject a custom encoder. Did not seem to be possible to do in any other way.