### PR TITLE
first draft for adding statsd reporting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,16 @@ pyArango collections have a caching system for documents that performs insertion
  #disable the cache
  humans.deactivateCache()
 
+Statsd Reporting
+----------------
+
+pyArango can optionally report query times to a statsd server for statistical evaluation.
+Its intended to be used in a two phase way: (we assume you're using bind values - right?)
+ - first run that will trigger all usecases. You create the connection by specifying statsdHost, statsdPort and reportFileName.
+   reportFilename will be filled with your queries paired with your hash identifiers. Its reported to statsd as 'pyArango_<hash>'.
+   you can later on use this digest to identify your queries to the gauges.
+ - on subsequent runs you only specify statsdHost and statsdPort; only the request times are reported to statsd.
+ 
 Examples
 ========
 More examples can be found in the examples directory.

--- a/README.rst
+++ b/README.rst
@@ -283,6 +283,12 @@ Statsd Reporting
 ----------------
 
 pyArango can optionally report query times to a statsd server for statistical evaluation.
+
+  import statsd
+  from pyArango.connection import Connection
+  statsdclient = statsd.StatsClient(os.environ.get('STATSD_HOST'), int(os.environ.get('STATSD_PORT')))
+  conn = Connection('http://127.0.0.1:8529', 'root', 'opensesame', statsdClient = statsdclient, reportFileName = '/tmp/queries.log')
+
 Its intended to be used in a two phase way: (we assume you're using bind values - right?)
  - first run that will trigger all usecases. You create the connection by specifying statsdHost, statsdPort and reportFileName.
    reportFilename will be filled with your queries paired with your hash identifiers. Its reported to statsd as 'pyArango_<hash>'.

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -1,6 +1,6 @@
 import requests
 import json
-import hashlib
+import uuid
 
 from datetime import datetime
 
@@ -93,6 +93,8 @@ class Connection(object) :
         else :
             self.arangoURL = arangoURL
 
+        self.identifier = None
+        self.startTime = None
         self.session = None
         self.resetSession(username, password)
 
@@ -169,7 +171,7 @@ class Connection(object) :
 
     def reportStart(self, name):
         if self.statsdc != None:
-            self.identifier = hashlib.sha224(name).hexdigest()[-6:]
+            self.identifier = str(uuid.uuid5(uuid.NAMESPACE_DNS, name))[-6:]
             if self.reportFile != None:
                 self.reportFile.write("[%s]: %s\n" % (self.identifier, name))
                 self.reportFile.flush()

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -109,8 +109,7 @@ class Connection(object) :
         else:
             self.reportFile = None
 
-        if statsdClient != None:
-            self.statsdc = statsdClient
+        self.statsdc = statsdClient
         self.reload()
 
     def disconnectSession(self) :

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -179,6 +179,6 @@ class Connection(object) :
 
     def reportItem(self):
         if self.statsdc != None:
-	    diff = datetime.now() - self.startTime
-	    microsecs = (diff.total_seconds() * 1000 * 1000) + diff.microseconds
+            diff = datetime.now() - self.startTime
+            microsecs = (diff.total_seconds() * (1000 ** 2) ) + diff.microseconds
             self.statsdc.timing("pyArango_" + self.identifier, int(microsecs))

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -1,5 +1,4 @@
 import requests
-import statsd
 import json
 import hashlib
 
@@ -84,7 +83,7 @@ class AikidoSession(object) :
 
 class Connection(object) :
     """This is the entry point in pyArango and directly handles databases."""
-    def __init__(self, arangoURL = 'http://127.0.0.1:8529', username = None, password = None, verbose = False, statsdHost = None, statsdPort = None, reportFileName = None) :
+    def __init__(self, arangoURL = 'http://127.0.0.1:8529', username = None, password = None, verbose = False, statsdClient = None, reportFileName = None) :
         self.databases = {}
         self.verbose = verbose
         if arangoURL[-1] == "/" :
@@ -110,10 +109,8 @@ class Connection(object) :
         else:
             self.reportFile = None
 
-        if statsdHost != None:
-            self.statsdc = statsd.StatsClient(statsdHost, statsdPort)
-        else:
-            self.statsdc = None
+        if statsdClient != None:
+            self.statsdc = statsdClient
         self.reload()
 
     def disconnectSession(self) :

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -204,7 +204,11 @@ class Database(object) :
         if params is not None:
             payload["params"] = params
 
+        self.connection.reportStart(action)
+
         r = self.connection.session.post(self.transactionURL, data = json.dumps(payload))
+
+        self.connection.reportItem()
 
         data = r.json()
 

--- a/pyArango/query.py
+++ b/pyArango/query.py
@@ -141,7 +141,9 @@ class AQLQuery(Query) :
         self.query = query
         self.database = database
         self.connection = self.database.connection
+        self.connection.reportStart(query)
         request = self.connection.session.post(database.cursorsURL, data = json.dumps(payload, cls=json_encoder))
+        self.connection.reportItem()
         Query.__init__(self, request, database, rawResults)
 
     def explain(self, allPlans = False) :

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
 
-    install_requires=['requests>=2.7.0', 'future'],
+    install_requires=['requests>=2.7.0', 'future', 'statsd', 'hashlib', 'datetime'],
 
     keywords='database ORM nosql arangodb driver validation',
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
 
-    install_requires=['requests>=2.7.0', 'future', 'statsd', 'hashlib', 'datetime'],
+    install_requires=['requests>=2.7.0', 'future', 'hashlib', 'datetime'],
 
     keywords='database ORM nosql arangodb driver validation',
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
 
-    install_requires=['requests>=2.7.0', 'future', 'hashlib', 'datetime'],
+    install_requires=['requests>=2.7.0', 'future', 'datetime'],
 
     keywords='database ORM nosql arangodb driver validation',
 


### PR DESCRIPTION
Hi, 
I've been working a bit to get pyArango emmit statsd statistics:
https://www.datadoghq.com/blog/statsd/

Basically one can use the statsd protocol to fire and forget send statistics via udp to a central service. 
Statsd will collect them, and aggredate them to an average, 95% percentile and some other values in a configured frequency.

Since its not that important all measured metrics actually arrive on the statsd side to get meaning full values, the UDP connection is basically used as a fire and forget thing, which should make the instrumentation lightweight to pyArango in terms of resource usage.

It should only be enabled if pyArango is initialized using this. 

I've used it in conjunction with the statsd implementation of http://colletd.org and it worked fine for me

I'd like to discuss whether this is the right approach to implement this, or whether another approach should be taken.