### PR TITLE
Enable usage of CachedDocs in Edge link()

### DIFF
--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -1,5 +1,5 @@
 import json, types
-
+from .collection import CachedDoc
 from .theExceptions import (CreationError, DeletionError, UpdateError, ValidationError, SchemaViolation, InvalidDocument)
 
 __all__ = ["DocumentStore", "Document", "Edge"]
@@ -401,23 +401,24 @@ class Edge(Document) :
         An alias to save that updates the _from and _to attributes.
         fromVertice and toVertice, can be either strings or documents. It they are unsaved documents, they will be automatically saved.
         """
-
-        if fromVertice.__class__ is Document :
+        if fromVertice.__class__ is Document or fromVertice.__class__ is CachedDoc:
             if not fromVertice._id :
                 fromVertice.save()
-
             self._from = fromVertice._id
-        elif (type(fromVertice) is bytes) or (type(fromVertice) is str) :
+        elif (type(fromVertice) is bytes) or (type(fromVertice) is str):
             self._from  = fromVertice
-
-        if toVertice.__class__ is Document :
-            if not toVertice._id :
+        elif not self._from:
+            raise CreationError('fromVertice %s is invalid!' % str(fromVertice))
+        
+        if toVertice.__class__ is Document or toVertice.__class__ is CachedDoc:
+            if not toVertice._id:
                 toVertice.save()
-
             self._to = toVertice._id
-        elif (type(toVertice) is bytes) or (type(toVertice) is str) :
+        elif (type(toVertice) is bytes) or (type(toVertice) is str):
             self._to = toVertice
-
+        elif not self._to:
+            raise CreationError('toVertice %s is invalid!' % str(toVertice))
+        
         self.save(**edgeArgs)
 
     def save(self, **edgeArgs) :

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -400,7 +400,7 @@ class Edge(Document) :
         An alias to save that updates the _from and _to attributes.
         fromVertice and toVertice, can be either strings or documents. It they are unsaved documents, they will be automatically saved.
         """
-        if fromVertice.__class__ is Document or getattr(fromVertice, 'document', None) is Document:
+        if fromVertice.__class__ is Document or getattr(fromVertice, 'document', None).__class__ is Document:
             if not fromVertice._id :
                 fromVertice.save()
             self._from = fromVertice._id
@@ -409,7 +409,7 @@ class Edge(Document) :
         elif not self._from:
             raise CreationError('fromVertice %s is invalid!' % str(fromVertice))
         
-        if toVertice.__class__ is Document or getattr(toVertice, 'document', None) is Document:
+        if toVertice.__class__ is Document or getattr(toVertice, 'document', None).__class__ is Document:
             if not toVertice._id:
                 toVertice.save()
             self._to = toVertice._id

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -1,5 +1,4 @@
 import json, types
-from .collection import CachedDoc
 from .theExceptions import (CreationError, DeletionError, UpdateError, ValidationError, SchemaViolation, InvalidDocument)
 
 __all__ = ["DocumentStore", "Document", "Edge"]
@@ -401,7 +400,7 @@ class Edge(Document) :
         An alias to save that updates the _from and _to attributes.
         fromVertice and toVertice, can be either strings or documents. It they are unsaved documents, they will be automatically saved.
         """
-        if fromVertice.__class__ is Document or fromVertice.__class__ is CachedDoc:
+        if fromVertice.__class__ is Document or getattr(fromVertice, 'document', None) is Document:
             if not fromVertice._id :
                 fromVertice.save()
             self._from = fromVertice._id
@@ -410,7 +409,7 @@ class Edge(Document) :
         elif not self._from:
             raise CreationError('fromVertice %s is invalid!' % str(fromVertice))
         
-        if toVertice.__class__ is Document or toVertice.__class__ is CachedDoc:
+        if toVertice.__class__ is Document or getattr(toVertice, 'document', None) is Document:
             if not toVertice._id:
                 toVertice.save()
             self._to = toVertice._id


### PR DESCRIPTION
`CachedDoc`s used to fail when used as vertices in `link()` method. `_from` and `_to` would fall through without being set due to class mismatches. This semi-implicitly checks for `CachedDoc` by checking for the `document` property, and adds an error condition if no properties are found and the `_from` and `_to` properties are not set.