### PR TITLE
Return details for bulk imports

### DIFF
--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -313,6 +313,7 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
         data = r.json()
         if not r.status_code == 201 or data["error"] :
             raise CreationError(data["errorMessage"], data)
+        return data
 
     def ensureHashIndex(self, fields, unique = False, sparse = True) :
         """Creates a hash index if it does not already exist, and returns it"""

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -15,13 +15,15 @@ class pyArangoTests(unittest.TestCase):
 
     def setUp(self):
         if __name__ == "__main__":
+            global ARANGODB_URL
             global ARANGODB_ROOT_USERNAME
             global ARANGODB_ROOT_PASSWORD
         else:
+            ARANGODB_URL = os.getenv('ARANGODB_URL', 'http://127.0.0.1:8529')
             ARANGODB_ROOT_USERNAME = os.getenv('ARANGODB_ROOT_USERNAME', 'root')
             ARANGODB_ROOT_PASSWORD = os.getenv('ARANGODB_ROOT_PASSWORD', 'root')
 
-        self.conn = Connection(username=ARANGODB_ROOT_USERNAME, password=ARANGODB_ROOT_PASSWORD)
+        self.conn = Connection(arangoURL=ARANGODB_URL, username=ARANGODB_ROOT_USERNAME, password=ARANGODB_ROOT_PASSWORD)
         try :
             self.conn.createDatabase(name = "test_db_2")
         except CreationError :
@@ -602,9 +604,8 @@ class pyArangoTests(unittest.TestCase):
 
         g.link('Friend', h4, h1, {})
         g.link('Friend', h4, h2, {})
-        g.link('Friend', h4, h3, {})
-        g.unlink('Friend', h4, h3)
-        self.assertEqual(len(h4.getEdges(rels)), 2)
+        g.unlink('Friend', h4, h2)
+        self.assertEqual(len(h4.getEdges(rels)), 1)
 
         h5 = g.createVertex('Humans', {"name" : "simba5"})
         h6 = g.createVertex('Humans', {"name" : "simba6"})
@@ -742,19 +743,18 @@ class pyArangoTests(unittest.TestCase):
     # @unittest.skip("stand by")
     def test_users_credentials(self) :
 
-        class persons(Collection) :
+        class persons(Collection):
             pass
-
-        pers = self.db.createCollection("persons")
 
         u = self.conn.users.createUser("pyArangoTest_tesla", "secure")
         u.save()
 
         u.setPermissions("test_db_2", True)
-        conn = Connection(username="pyArangoTest_tesla", password="secure")
+        global ARANGODB_URL
+        conn = Connection(arangoURL=ARANGODB_URL, username="pyArangoTest_tesla", password="secure")
 
-        self.assertRaises( KeyError, conn.__getitem__, "_system" )
-        self.assertTrue( conn.hasDatabase("test_db_2") )
+        self.assertRaises(KeyError, conn.__getitem__, "_system")
+        self.assertTrue(conn.hasDatabase("test_db_2"))
 
     # @unittest.skip("stand by")
     def test_users_update(self) :
@@ -763,22 +763,28 @@ class pyArangoTests(unittest.TestCase):
         u.save()
 
         u.setPermissions("test_db_2", True)
-        conn = Connection(username="pyArangoTest_tesla", password="secure")
+
+        global ARANGODB_URL
+        Connection(arangoURL=ARANGODB_URL, username="pyArangoTest_tesla", password="secure")
 
         u["password"] = "newpass"
         u.save()
-        conn = Connection(username="pyArangoTest_tesla", password="newpass")
+
+        Connection(arangoURL=ARANGODB_URL, username="pyArangoTest_tesla", password="newpass")
+
 
 if __name__ == "__main__" :
-
     # Change default username/password in bash like this:
     # export ARANGODB_ROOT_USERNAME=myUserName
     # export ARANGODB_ROOT_PASSWORD=myPassword
+    # export ARANGODB_URL=myURL
     global ARANGODB_ROOT_USERNAME
     global ARANGODB_ROOT_PASSWORD
+    global ARANGODB_URL
 
     ARANGODB_ROOT_USERNAME = os.getenv('ARANGODB_ROOT_USERNAME', None)
     ARANGODB_ROOT_PASSWORD = os.getenv('ARANGODB_ROOT_PASSWORD', None)
+    ARANGODB_URL = os.getenv('ARANGODB_URL', 'http://127.0.0.1:8529')
 
     if ARANGODB_ROOT_USERNAME is None :
         try :

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -74,6 +74,45 @@ class pyArangoTests(unittest.TestCase):
         self.assertEqual(usersCollection.count(), len(users))
 
     # @unittest.skip("stand by")
+    def test_bulk_import_exception(self):
+        usersCollection = self.db.createCollection(name="users")
+        nbUsers = 2
+        users = []
+        for i in range(nbUsers):
+            user = {}
+            user["_key"] = "tesla"
+            user["name"] = "Tesla-%d" % i
+            user["number"] = i
+            user["species"] = "human"
+            users.append(user)
+        with self.assertRaises(CreationError):
+            usersCollection.importBulk(users, onDuplicate="error", complete=True)
+        self.assertEqual(usersCollection.count(), 0)
+
+        # @unittest.skip("stand by")
+
+    def test_bulk_import_error_return_value(self):
+        usersCollection = self.db.createCollection(name="users")
+        nbUsers = 2
+        users = []
+        for i in range(nbUsers):
+            user = {}
+            user["_key"] = "tesla"
+            user["name"] = "Tesla-%d" % i
+            user["number"] = i
+            user["species"] = "human"
+            users.append(user)
+        result = usersCollection.importBulk(users, onDuplicate="error")
+        self.assertEqual(result, {
+            'created': 1,
+            'empty': 0,
+            'error': False,
+            'errors': 1,
+            'ignored': 0,
+            'updated': 0
+        })
+
+    # @unittest.skip("stand by")
     def test_bulkSave(self) :
         collection = self.db.createCollection(name = "lops")
         nbUsers = 100


### PR DESCRIPTION
I added the return of the details for a bulk import to the end user of this library. We needed this for taking further actions and give the user feedback how their data import went. 

It's a simple one line addition. I also added tests for the case of an exception and for the case of the return of the description data from the import.

Cheers

P.S. I had to fix on etest case in the unit tests and I added a ARANGODB_URL environmen var, in case some (like me) has running arango on a different port.