### PR TITLE
Is is used insted of instanceof

### DIFF
--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -672,9 +672,9 @@ class Edges(Collection) :
     def getEdges(self, vertex, inEdges = True, outEdges = True, rawResults = False) :
         """returns in, out, or both edges liked to a given document. vertex can be either a Document object or a string for an _id.
         If rawResults a arango results will be return as fetched, if false, will return a liste of Edge objects"""
-        if vertex.__class__ is Document :
+        if isinstance(vertex, Document):
             vId = vertex._id
-        elif (type(vertex) is str) or (type(vertex) is bytes) :
+        elif (type(vertex) is str) or (type(vertex) is bytes):
             vId = vertex
         else :
             raise ValueError("Vertex is neither a Document nor a String")

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -400,7 +400,7 @@ class Edge(Document) :
         An alias to save that updates the _from and _to attributes.
         fromVertice and toVertice, can be either strings or documents. It they are unsaved documents, they will be automatically saved.
         """
-        if fromVertice.__class__ is Document or getattr(fromVertice, 'document', None).__class__ is Document:
+        if isinstance(fromVertice, Document) or isinstance(getattr(fromVertice, 'document', None), Document):
             if not fromVertice._id :
                 fromVertice.save()
             self._from = fromVertice._id
@@ -409,7 +409,7 @@ class Edge(Document) :
         elif not self._from:
             raise CreationError('fromVertice %s is invalid!' % str(fromVertice))
         
-        if toVertice.__class__ is Document or getattr(toVertice, 'document', None).__class__ is Document:
+        if isinstance(toVertice, Document) or isinstance(getattr(toVertice, 'document', None), Document):
             if not toVertice._id:
                 toVertice.save()
             self._to = toVertice._id

--- a/pyArango/query.py
+++ b/pyArango/query.py
@@ -111,7 +111,7 @@ class Query(object) :
 
     def __getitem__(self, i) :
         "returns a ith result of the query."
-        if not self.rawResults and (self.result[i].__class__ is not Edge and self.result[i].__class__ is not Document) : 
+        if not self.rawResults and (not isinstance(self.result[i], (Edge, Document))):
             self._developDoc(i)
         return self.result[i]
 

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -15,13 +15,15 @@ class pyArangoTests(unittest.TestCase):
 
     def setUp(self):
         if __name__ == "__main__":
+            global ARANGODB_URL
             global ARANGODB_ROOT_USERNAME
             global ARANGODB_ROOT_PASSWORD
         else:
+            ARANGODB_URL = os.getenv('ARANGODB_URL', 'http://127.0.0.1:8529')
             ARANGODB_ROOT_USERNAME = os.getenv('ARANGODB_ROOT_USERNAME', 'root')
             ARANGODB_ROOT_PASSWORD = os.getenv('ARANGODB_ROOT_PASSWORD', 'root')
 
-        self.conn = Connection(username=ARANGODB_ROOT_USERNAME, password=ARANGODB_ROOT_PASSWORD)
+        self.conn = Connection(arangoURL=ARANGODB_URL, username=ARANGODB_ROOT_USERNAME, password=ARANGODB_ROOT_PASSWORD)
         try :
             self.conn.createDatabase(name = "test_db_2")
         except CreationError :
@@ -602,9 +604,8 @@ class pyArangoTests(unittest.TestCase):
 
         g.link('Friend', h4, h1, {})
         g.link('Friend', h4, h2, {})
-        g.link('Friend', h4, h3, {})
-        g.unlink('Friend', h4, h3)
-        self.assertEqual(len(h4.getEdges(rels)), 2)
+        g.unlink('Friend', h4, h2)
+        self.assertEqual(len(h4.getEdges(rels)), 1)
 
         h5 = g.createVertex('Humans', {"name" : "simba5"})
         h6 = g.createVertex('Humans', {"name" : "simba6"})
@@ -742,19 +743,18 @@ class pyArangoTests(unittest.TestCase):
     # @unittest.skip("stand by")
     def test_users_credentials(self) :
 
-        class persons(Collection) :
+        class persons(Collection):
             pass
-
-        pers = self.db.createCollection("persons")
 
         u = self.conn.users.createUser("pyArangoTest_tesla", "secure")
         u.save()
 
         u.setPermissions("test_db_2", True)
-        conn = Connection(username="pyArangoTest_tesla", password="secure")
+        global ARANGODB_URL
+        conn = Connection(arangoURL=ARANGODB_URL, username="pyArangoTest_tesla", password="secure")
 
-        self.assertRaises( KeyError, conn.__getitem__, "_system" )
-        self.assertTrue( conn.hasDatabase("test_db_2") )
+        self.assertRaises(KeyError, conn.__getitem__, "_system")
+        self.assertTrue(conn.hasDatabase("test_db_2"))
 
     # @unittest.skip("stand by")
     def test_users_update(self) :
@@ -763,22 +763,28 @@ class pyArangoTests(unittest.TestCase):
         u.save()
 
         u.setPermissions("test_db_2", True)
-        conn = Connection(username="pyArangoTest_tesla", password="secure")
+
+        global ARANGODB_URL
+        Connection(arangoURL=ARANGODB_URL, username="pyArangoTest_tesla", password="secure")
 
         u["password"] = "newpass"
         u.save()
-        conn = Connection(username="pyArangoTest_tesla", password="newpass")
+
+        Connection(arangoURL=ARANGODB_URL, username="pyArangoTest_tesla", password="newpass")
+
 
 if __name__ == "__main__" :
-
     # Change default username/password in bash like this:
     # export ARANGODB_ROOT_USERNAME=myUserName
     # export ARANGODB_ROOT_PASSWORD=myPassword
+    # export ARANGODB_URL=myURL
     global ARANGODB_ROOT_USERNAME
     global ARANGODB_ROOT_PASSWORD
+    global ARANGODB_URL
 
     ARANGODB_ROOT_USERNAME = os.getenv('ARANGODB_ROOT_USERNAME', None)
     ARANGODB_ROOT_PASSWORD = os.getenv('ARANGODB_ROOT_PASSWORD', None)
+    ARANGODB_URL = os.getenv('ARANGODB_URL', 'http://127.0.0.1:8529')
 
     if ARANGODB_ROOT_USERNAME is None :
         try :


### PR DESCRIPTION
I changed `x.__class__ is Y` everywhere to `instanceof(x, Y)` where x is an object so that we can use subclasses of Y as well. This is useful in case we're injecting our own documentClass for a collection since the function to link documents are looking for instances of Document to use the `_id` property.